### PR TITLE
Fix README install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ pip install flash-attn --no-build-isolation
 pip install warpconvnet
 
 # Or install from source
-pip install git+https://github.com/NVlabs/warpconvnet.git
+git clone https://github.com/NVlabs/WarpConvNet.git
+cd WarpConvNet
+git submodule update --init 3rdparty/cutlass
+pip install .
 ```
 
 Available optional dependency groups:
@@ -109,7 +112,7 @@ Build and run with GPU support:
 
 ```bash
 # Build container
-cd warpconvnet/docker
+cd docker
 docker build -t warpconvnet .
 
 # Run container


### PR DESCRIPTION
## Summary
- correct Docker directory path
- document how to build from source with submodules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687007bd342c8333aec4d3ff8c329a78