### PR TITLE
Add initial docs site with MkDocs

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,5 @@
+# Core
+
+::: warpconvnet
+    options:
+      members_order: source

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -1,0 +1,8 @@
+# Dataset
+
+The `warpconvnet.dataset` module provides dataset loaders.
+
+```python
+from warpconvnet.dataset.modelnet import ModelNet40Dataset
+from warpconvnet.dataset.scannet import ScanNetDataset
+```

--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -1,0 +1,3 @@
+# Geometry
+
+::: warpconvnet.geometry

--- a/docs/api/misc.md
+++ b/docs/api/misc.md
@@ -1,0 +1,3 @@
+# Miscellaneous
+
+Additional helpers and utilities are organized under various modules.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,3 @@
+# Models
+
+WarpConvNet currently does not ship pre-defined models, but this section is reserved for future additions.

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -1,0 +1,3 @@
+# Neural Networks
+
+::: warpconvnet.nn

--- a/docs/api/ops.md
+++ b/docs/api/ops.md
@@ -1,0 +1,3 @@
+# Operations
+
+The `warpconvnet.ops` module contains low-level tensor operations such as reductions.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,5 @@
+# Types
+
+```python
+from warpconvnet.types import IntCoords, RealCoords
+```

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,3 @@
+# Utils
+
+::: warpconvnet.utils

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Contributions are welcome! Feel free to open issues or pull requests on GitHub.

--- a/docs/examples/modelnet.md
+++ b/docs/examples/modelnet.md
@@ -1,0 +1,5 @@
+# ModelNet Example
+
+```bash
+python examples/modelnet.py
+```

--- a/docs/examples/scannet.md
+++ b/docs/examples/scannet.md
@@ -1,0 +1,6 @@
+# ScanNet Example
+
+```bash
+pip install warpconvnet[models]
+python examples/scannet.py train.batch_size=12 model=mink_unet
+```

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,0 +1,16 @@
+# Installation
+
+WarpConvNet requires Python >= 3.9 and a working CUDA toolchain. The library can be installed from source.
+
+```bash
+# Install PyTorch for your CUDA version
+export CUDA=cu128
+pip install torch torchvision --index-url https://download.pytorch.org/whl/${CUDA}
+
+# Install dependencies and WarpConvNet
+pip install build ninja
+pip install cupy-cuda12x
+pip install git+https://github.com/rusty1s/pytorch_scatter.git
+pip install flash-attn --no-build-isolation
+pip install .
+```

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,0 +1,14 @@
+# Quick Start
+
+After installation you can quickly verify the package with the ModelNet example:
+
+```bash
+python examples/modelnet.py
+```
+
+For ScanNet semantic segmentation:
+
+```bash
+pip install warpconvnet[models]
+python examples/scannet.py train.batch_size=12 model=mink_unet
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# WarpConvNet
+
+Welcome to the WarpConvNet documentation.
+
+WarpConvNet is a high-performance 3D deep learning library built on NVIDIA's Warp framework. It provides tools for point cloud processing and sparse voxel convolutions.
+
+Use the navigation on the left to explore the guides and API reference.

--- a/docs/user_guide/concepts.md
+++ b/docs/user_guide/concepts.md
@@ -1,0 +1,3 @@
+# Basic Concepts
+
+WarpConvNet is built around coordinate and feature tensors that represent 3D data. Coordinates are stored in integer or real form and are batched for efficiency.

--- a/docs/user_guide/geometry_tutorial.md
+++ b/docs/user_guide/geometry_tutorial.md
@@ -1,0 +1,41 @@
+# Geometry Tutorial
+
+This tutorial demonstrates how to create basic geometry types used by WarpConvNet.
+
+## Creating `Points`
+
+```python
+import torch
+from warpconvnet.geometry.types.points import Points
+
+# coordinates and features for two batches
+coords = [torch.rand(1000, 3), torch.rand(500, 3)]
+features = [torch.rand(1000, 7), torch.rand(500, 7)]
+
+points = Points(coords, features)
+print(points.batch_size)
+```
+
+## Creating `Voxels`
+
+```python
+from warpconvnet.geometry.types.voxels import Voxels
+
+voxel_size = 0.01
+voxel_coords = [
+    (torch.rand(1000, 3) / voxel_size).int(),
+    (torch.rand(500, 3) / voxel_size).int(),
+]
+voxel_feats = [torch.rand(1000, 7), torch.rand(500, 7)]
+
+voxels = Voxels(voxel_coords, voxel_feats)
+print(voxels.batch_size)
+```
+
+`Points` can be downsampled into `Voxels` and voxel grids can be converted back to dense tensors:
+
+```python
+downsampled = points.voxel_downsample(voxel_size)
+dense = voxels.to_dense(channel_dim=1)
+restored = Voxels.from_dense(dense, dense_tensor_channel_dim=1)
+```

--- a/docs/user_guide/geometry_types.md
+++ b/docs/user_guide/geometry_types.md
@@ -1,0 +1,76 @@
+# Geometry Types
+
+WarpConvNet defines a set of geometry containers that combine batched coordinates and features. They provide utility functions for neighbor search, conversions and indexing. The tests in `tests/types` showcase typical usage while the source code under `warpconvnet/geometry/types` contains the full definitions.
+
+## Points
+
+`Points` represent unordered sets of positions with per-point features.
+
+```python
+import torch
+from warpconvnet.geometry.types.points import Points
+
+coords = [torch.rand(1000, 3), torch.rand(500, 3)]
+features = [torch.rand(1000, 7), torch.rand(500, 7)]
+points = Points(coords, features)
+print(points.batch_size)  # 2
+```
+
+Downsampling and neighbor search utilities are provided. See `tests/types/test_points.py` for additional examples.
+
+## Voxels
+
+`Voxels` store integer grid coordinates and features. They can be constructed directly or converted from dense tensors.
+
+```python
+from warpconvnet.geometry.types.voxels import Voxels
+
+voxel_size = 0.01
+voxel_coords = [(torch.rand(1000, 3) / voxel_size).int(),
+                (torch.rand(500, 3) / voxel_size).int()]
+voxel_feats = [torch.rand(1000, 7), torch.rand(500, 7)]
+voxels = Voxels(voxel_coords, voxel_feats)
+```
+
+Conversion to and from dense representations is demonstrated in `tests/types/test_voxels.py`.
+
+## Grid
+
+`Grid` is a dense voxel grid with a fixed shape and memory format.
+
+```python
+from warpconvnet.geometry.types.grid import Grid, GridMemoryFormat
+
+grid = Grid.from_shape(
+    grid_shape=(4, 6, 8),
+    num_channels=16,
+    memory_format=GridMemoryFormat.b_x_y_z_c,
+    batch_size=2,
+)
+```
+
+Conversion helpers like `points_to_grid` are illustrated in `tests/types/test_grid.py` and `tests/types/test_to_grid.py`.
+
+## FactorGrid
+
+`FactorGrid` groups multiple `Grid` objects with different factorized memory formats.
+
+```python
+from warpconvnet.geometry.types.factor_grid import FactorGrid
+from warpconvnet.geometry.features.grid import GridMemoryFormat
+
+factor = FactorGrid.create_from_grid_shape(
+    [(2, 32, 64), (16, 2, 64), (16, 32, 2)],
+    num_channels=7,
+    memory_formats=[
+        GridMemoryFormat.b_zc_x_y,
+        GridMemoryFormat.b_xc_y_z,
+        GridMemoryFormat.b_yc_x_z,
+    ],
+    batch_size=2,
+)
+```
+
+Detailed usage can be found in `tests/types/test_factor_grid.py`.
+
+For complete API documentation consult the modules under `warpconvnet/geometry/types/`.

--- a/docs/user_guide/network_tutorial.md
+++ b/docs/user_guide/network_tutorial.md
@@ -1,0 +1,82 @@
+# Network Creation Tutorial
+
+This tutorial walks through building neural networks with WarpConvNet modules. The code snippets are simplified versions of the example scripts in the `examples` folder.
+
+## MNIST Example
+
+The `examples/mnist.py` script constructs a small network for classifying 2‑D images using sparse convolutions:
+
+```python
+import torch
+import torch.nn as nn
+from warpconvnet.geometry.types.voxels import Voxels
+from warpconvnet.nn.functional.sparse_pool import sparse_max_pool
+from warpconvnet.nn.modules.sequential import Sequential
+from warpconvnet.nn.modules.sparse_conv import SparseConv2d
+
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = Sequential(
+            SparseConv2d(1, 32, kernel_size=3, stride=1),
+            nn.ReLU(),
+            SparseConv2d(32, 64, kernel_size=3, stride=1),
+            nn.ReLU(),
+        )
+        self.head = nn.Sequential(
+            nn.Dropout(0.25),
+            nn.Linear(14 * 14 * 64, 128),
+            nn.ReLU(),
+            nn.Dropout(0.5),
+            nn.Linear(128, 10),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = Voxels.from_dense(x)
+        x = self.layers(x)
+        x = sparse_max_pool(x, kernel_size=(2, 2), stride=(2, 2))
+        x = x.to_dense(channel_dim=1, spatial_shape=(14, 14))
+        x = torch.flatten(x, 1)
+        return self.head(x)
+```
+
+## ModelNet Example
+
+For 3‑D data a combination of point and sparse convolutions can be used. The following snippet is adapted from `examples/modelnet.py`:
+
+```python
+import torch
+import torch.nn as nn
+from warpconvnet.geometry.coords.search.search_configs import RealSearchConfig
+from warpconvnet.geometry.types.points import Points
+from warpconvnet.nn.modules.point_conv import PointConv
+from warpconvnet.nn.modules.sequential import Sequential
+from warpconvnet.nn.modules.sparse_conv import SparseConv3d
+
+class UseAllConvNet(nn.Module):
+    def __init__(self, voxel_size: float = 0.05):
+        super().__init__()
+        self.point_conv = Sequential(
+            PointConv(24, 64, neighbor_search_args=RealSearchConfig("knn", knn_k=16)),
+            nn.LayerNorm(64),
+            nn.ReLU(),
+            PointConv(64, 64, neighbor_search_args=RealSearchConfig("radius", radius=voxel_size)),
+            nn.LayerNorm(64),
+            nn.ReLU(),
+        )
+        self.voxel_size = voxel_size
+        self.sparse_conv = Sequential(
+            SparseConv3d(64, 64, kernel_size=3, stride=1),
+            nn.LayerNorm(64),
+            nn.ReLU(),
+        )
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        pc = Points.from_list_of_coordinates(coords, encoding_channels=8, encoding_range=1)
+        pc = self.point_conv(pc)
+        st = pc.to_voxels(reduction="max", voxel_size=self.voxel_size)
+        st = self.sparse_conv(st)
+        return st.to_dense(channel_dim=1)
+```
+
+These examples demonstrate how geometry‑aware modules such as `PointConv` and `SparseConv3d` can be combined using `Sequential` to form end‑to‑end networks. Refer to the full example scripts for the training loops and data handling.

--- a/docs/user_guide/normalizations.md
+++ b/docs/user_guide/normalizations.md
@@ -1,0 +1,3 @@
+# Normalizations
+
+A set of normalization layers are included to process sparse data and point clouds.

--- a/docs/user_guide/point_convolutions.md
+++ b/docs/user_guide/point_convolutions.md
@@ -1,0 +1,3 @@
+# Point Convolutions
+
+Point based operations are provided for unstructured data such as point clouds.

--- a/docs/user_guide/sparse_convolutions.md
+++ b/docs/user_guide/sparse_convolutions.md
@@ -1,0 +1,3 @@
+# Sparse Convolutions
+
+WarpConvNet implements efficient spatially sparse convolutions on voxel grids using CUDA and Warp kernels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,29 +29,15 @@ theme:
 plugins:
   - search
   - mkdocstrings:
-      default_handler: python
       handlers:
         python:
-          paths: [warpconvnet]
+          paths: [.]
           options:
             show_source: true
             show_root_heading: true
-            heading_level: 2
             docstring_style: numpy
             show_signature_annotations: true
-            separate_signature: true
-            show_if_no_docstring: false
-            filters: ["!^_"]  # Hide private members
-            docstring_section_style: spacy
-          import:
-            - https://docs.python.org/3/objects.inv
-            - https://pytorch.org/docs/stable/objects.inv
-          selection:
-            docstring_style: numpy
-            inherited_members: true
-            filters:
-              - "!^_"  # Hide private members
-              - "^__init__$"  # But show __init__
+            filters: ["!^_"]
 
 markdown_extensions:
   - pymdownx.arithmatex:  # For LaTeX math equations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,9 @@ nav:
     - Quick Start: getting_started/quickstart.md
   - User Guide:
     - Basic Concepts: user_guide/concepts.md
+    - Geometry Types: user_guide/geometry_types.md
+    - Geometry Tutorial: user_guide/geometry_tutorial.md
+    - Network Tutorial: user_guide/network_tutorial.md
     - Sparse Convolutions: user_guide/sparse_convolutions.md
     - Point Convolutions: user_guide/point_convolutions.md
     - Normalizations: user_guide/normalizations.md

--- a/warpconvnet/nn/functional/global_pool.py
+++ b/warpconvnet/nn/functional/global_pool.py
@@ -28,6 +28,15 @@ def _global_pool(
 
 
 def global_pool(x: Geometry, reduce: Literal["max", "mean", "sum"]) -> Geometry:
+    """Pool over all coordinates and return a single feature per batch.
+
+    Args:
+        x: Input geometry instance to pool.
+        reduce: Reduction type used to combine features.
+
+    Returns:
+        Geometry object with a single coordinate and feature per batch.
+    """
     B = x.batch_size
     num_spatial_dims = x.num_spatial_dims
     # Generate output coordinates
@@ -38,7 +47,9 @@ def global_pool(x: Geometry, reduce: Literal["max", "mean", "sum"]) -> Geometry:
     output_features = _global_pool(x, reduce)
 
     return x.replace(
-        batched_coordinates=x.batched_coordinates.__class__(output_coords, output_offsets),
+        batched_coordinates=x.batched_coordinates.__class__(
+            output_coords, output_offsets
+        ),
         batched_features=x.batched_features.__class__(output_features, output_offsets),
         offsets=output_offsets,
     )

--- a/warpconvnet/nn/functional/point_unpool.py
+++ b/warpconvnet/nn/functional/point_unpool.py
@@ -20,8 +20,11 @@ def _unpool_features(
     pooled_pc: "Points",  # noqa: F821
     unpooled_pc: "Points",  # noqa: F821
     to_unique: Optional[ToUnique] = None,
-    unpooling_mode: Optional[Union[str, FEATURE_UNPOOLING_MODE]] = FEATURE_UNPOOLING_MODE.REPEAT,
+    unpooling_mode: Optional[
+        Union[str, FEATURE_UNPOOLING_MODE]
+    ] = FEATURE_UNPOOLING_MODE.REPEAT,
 ) -> Float[Tensor, "M C"]:
+    """Compute unpooled features for ``unpooled_pc`` from ``pooled_pc``."""
     if isinstance(unpooling_mode, str):
         unpooling_mode = FEATURE_UNPOOLING_MODE(unpooling_mode)
 
@@ -44,9 +47,12 @@ def point_unpool(
     pooled_pc: "BatchedSpatialFeatures",  # noqa: F821
     unpooled_pc: "Points",  # noqa: F821
     concat_unpooled_pc: bool,
-    unpooling_mode: Optional[Union[str, FEATURE_UNPOOLING_MODE]] = FEATURE_UNPOOLING_MODE.REPEAT,
+    unpooling_mode: Optional[
+        Union[str, FEATURE_UNPOOLING_MODE]
+    ] = FEATURE_UNPOOLING_MODE.REPEAT,
     to_unique: Optional[ToUnique] = None,
 ) -> "Points":  # noqa: F821
+    """Unpool features to a denser set of points."""
     unpooled_features = _unpool_features(
         pooled_pc=pooled_pc,
         unpooled_pc=unpooled_pc,
@@ -54,5 +60,7 @@ def point_unpool(
         unpooling_mode=unpooling_mode,
     )
     if concat_unpooled_pc:
-        unpooled_features = torch.cat((unpooled_features, unpooled_pc.feature_tensor), dim=-1)
+        unpooled_features = torch.cat(
+            (unpooled_features, unpooled_pc.feature_tensor), dim=-1
+        )
     return unpooled_pc.replace(batched_features=unpooled_features)

--- a/warpconvnet/nn/modules/activations.py
+++ b/warpconvnet/nn/modules/activations.py
@@ -34,6 +34,14 @@ __all__ = [
 
 
 class ReLU(BaseSpatialModule):
+    """Apply the ReLU activation to ``Geometry`` features.
+
+    Parameters
+    ----------
+    inplace : bool, optional
+        Whether to perform the operation in-place. Defaults to ``False``.
+    """
+
     def __init__(self, inplace: bool = False):
         super().__init__()
         self.relu = nn.ReLU(inplace=inplace)
@@ -46,54 +54,77 @@ class ReLU(BaseSpatialModule):
 
 
 class GELU(BaseSpatialModule):
+    """Applies the GELU activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return gelu(input)
 
 
 class SiLU(BaseSpatialModule):
+    """Applies the SiLU activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return silu(input)
 
 
 class Tanh(BaseSpatialModule):
+    """Applies the ``tanh`` activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return tanh(input)
 
 
 class Sigmoid(BaseSpatialModule):
+    """Applies the sigmoid activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return sigmoid(input)
 
 
 class LeakyReLU(nn.Module):
+    """Applies the LeakyReLU activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return leaky_relu(input)
 
 
 class ELU(BaseSpatialModule):
+    """Applies the ELU activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return elu(input)
 
 
 class Softmax(BaseSpatialModule):
+    """Applies the ``softmax`` activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return softmax(input)
 
 
 class LogSoftmax(BaseSpatialModule):
+    """Applies the ``log_softmax`` activation to ``Geometry`` features."""
+
     def forward(self, input: Geometry):  # noqa: F821
         return log_softmax(input)
 
 
 # From https://github.com/huggingface/pytorch-image-models/blob/main/timm/layers/drop.py
-def drop_path(x, drop_prob: float = 0.0, training: bool = False, scale_by_keep: bool = True):
-    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+def drop_path(
+    x, drop_prob: float = 0.0, training: bool = False, scale_by_keep: bool = True
+):
+    """Apply stochastic depth to the input tensor.
 
-    This is the same as the DropConnect impl I created for EfficientNet, etc networks, however,
-    the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
-    See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-532968956 ... I've opted for
-    changing the layer and argument names to 'drop path' rather than mix DropConnect as a layer name and use
-    'survival rate' as the argument.
+    Parameters
+    ----------
+    x : ``torch.Tensor``
+        Input tensor to apply stochastic depth to.
+    drop_prob : float, optional
+        Probability of dropping a sample. Defaults to ``0.0``.
+    training : bool, optional
+        Whether the module is in training mode. Defaults to ``False``.
+    scale_by_keep : bool, optional
+        If ``True`` the output is scaled by ``1 - drop_prob``. Defaults to ``True``.
     """
     if drop_prob == 0.0 or not training:
         return x
@@ -106,7 +137,15 @@ def drop_path(x, drop_prob: float = 0.0, training: bool = False, scale_by_keep: 
 
 
 class DropPath(BaseSpatialModule):
-    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+    """Stochastic depth regularization.
+
+    Parameters
+    ----------
+    drop_prob : float, optional
+        Probability of dropping a sample. Defaults to ``0.0``.
+    scale_by_keep : bool, optional
+        If ``True`` the output is scaled by ``1 - drop_prob``. Defaults to ``True``.
+    """
 
     def __init__(self, drop_prob: float = 0.0, scale_by_keep: bool = True):
         super().__init__()

--- a/warpconvnet/nn/modules/grid_conv.py
+++ b/warpconvnet/nn/modules/grid_conv.py
@@ -15,6 +15,31 @@ from warpconvnet.utils.ntuple import ntuple
 
 
 class GridConv(BaseSpatialModule):
+    """Convolutional layer for :class:`~warpconvnet.geometry.types.grid.Grid` data.
+
+    Parameters mirror those of :class:`torch.nn.Conv3d` but operate on a
+    ``Grid`` object instead of plain tensors.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input feature channels.
+    out_channels : int
+        Number of output feature channels.
+    kernel_size : int or tuple of int
+        Size of the convolution kernel.
+    stride : int or tuple of int, optional
+        Stride of the convolution. Defaults to ``1``.
+    padding : int or tuple of int, optional
+        Zero-padding added to all three sides of the input. Defaults to ``0``.
+    dilation : int or tuple of int, optional
+        Spacing between kernel elements. Defaults to ``1``.
+    bias : bool, optional
+        If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+    num_spatial_dims : int, optional
+        Number of spatial dimensions. Defaults to ``3``.
+    """
+
     def __init__(
         self,
         in_channels: int,

--- a/warpconvnet/nn/modules/mlp.py
+++ b/warpconvnet/nn/modules/mlp.py
@@ -15,6 +15,22 @@ __all__ = ["FeatureResidualMLPBlock", "Linear"]
 
 
 class FeatureMLPBlock(nn.Module):
+    """Simple fully connected block with activation and normalization.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    out_channels : int
+        Number of output features.
+    hidden_channels : int, optional
+        Size of the hidden layer. Defaults to ``None`` which uses ``in_channels``.
+    activation : ``nn.Module``, optional
+        Activation module to apply. Defaults to :class:`torch.nn.ReLU`.
+    bias : bool, optional
+        If ``True`` adds bias terms to the linear layers. Defaults to ``True``.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -35,6 +51,22 @@ class FeatureMLPBlock(nn.Module):
 
 
 class FeatureResidualMLPBlock(nn.Module):
+    """MLP block with a residual connection.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    out_channels : int, optional
+        Number of output features. Defaults to ``in_channels``.
+    hidden_channels : int, optional
+        Hidden layer size. Defaults to ``in_channels``.
+    activation : ``nn.Module``, optional
+        Activation module to apply. Defaults to :class:`torch.nn.ReLU`.
+    bias : bool, optional
+        If ``True`` adds bias terms to the linear layers. Defaults to ``True``.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -69,6 +101,18 @@ class FeatureResidualMLPBlock(nn.Module):
 
 
 class Linear(BaseSpatialModule):
+    """Apply a linear layer to ``Geometry`` features.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    out_features : int
+        Number of output features.
+    bias : bool, optional
+        If ``True`` adds a bias term to the layer. Defaults to ``True``.
+    """
+
     def __init__(self, in_features: int, out_features: int, bias: bool = True):
         super().__init__()
         self.block = nn.Linear(in_features, out_features, bias=bias)
@@ -78,6 +122,18 @@ class Linear(BaseSpatialModule):
 
 
 class LinearNormActivation(BaseSpatialModule):
+    """Linear layer followed by ``LayerNorm`` and ``ReLU``.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    out_features : int
+        Number of output features.
+    bias : bool, optional
+        Whether to include a bias term. Defaults to ``True``.
+    """
+
     def __init__(self, in_features: int, out_features: int, bias: bool = True):
         super().__init__()
         self.block = nn.Sequential(
@@ -91,7 +147,21 @@ class LinearNormActivation(BaseSpatialModule):
 
 
 class ResidualMLPBlock(FeatureResidualMLPBlock):
-    def __init__(self, in_features: int, out_features: int = None, hidden_features: int = None):
+    """Residual MLP block operating on ``Geometry`` features.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    out_features : int, optional
+        Number of output features. Defaults to ``in_features``.
+    hidden_features : int, optional
+        Size of the hidden layer. Defaults to ``in_features``.
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int = None, hidden_features: int = None
+    ):
         super().__init__(in_features, out_features, hidden_features)
 
     def forward(self, x: Geometry):

--- a/warpconvnet/nn/modules/normalizations.py
+++ b/warpconvnet/nn/modules/normalizations.py
@@ -24,6 +24,14 @@ __all__ = [
 
 
 class NormalizationBase(BaseSpatialModule):
+    """Wrapper for applying a normalization module to ``Geometry`` features.
+
+    Parameters
+    ----------
+    norm : ``nn.Module``
+        Normalization module to apply to the feature tensor.
+    """
+
     def __init__(self, norm: nn.Module):
         super().__init__()
         self.norm = norm
@@ -39,11 +47,37 @@ class NormalizationBase(BaseSpatialModule):
 
 
 class BatchNorm(NormalizationBase):
+    """Applies :class:`torch.nn.BatchNorm1d` to ``Geometry`` features.
+
+    Parameters
+    ----------
+    num_features : int
+        Number of feature channels in the input.
+    eps : float, optional
+        Value added to the denominator for numerical stability. Defaults to ``1e-5``.
+    momentum : float, optional
+        Momentum factor for the running statistics. Defaults to ``0.1``.
+    """
+
     def __init__(self, num_features: int, eps: float = 1e-5, momentum: float = 0.1):
         super().__init__(nn.BatchNorm1d(num_features, eps=eps, momentum=momentum))
 
 
 class LayerNorm(NormalizationBase):
+    """Applies :class:`torch.nn.LayerNorm` to ``Geometry`` features.
+
+    Parameters
+    ----------
+    normalized_shape : list of int
+        Input shape from an expected input.
+    eps : float, optional
+        A value added to the denominator for numerical stability. Defaults to ``1e-5``.
+    elementwise_affine : bool, optional
+        Whether to learn elementwise affine parameters. Defaults to ``True``.
+    bias : bool, optional
+        If ``True`` adds bias parameters. Defaults to ``True``.
+    """
+
     def __init__(
         self,
         normalized_shape: List[int],
@@ -53,17 +87,39 @@ class LayerNorm(NormalizationBase):
     ):
         super().__init__(
             nn.LayerNorm(
-                normalized_shape, eps=eps, elementwise_affine=elementwise_affine, bias=bias
+                normalized_shape,
+                eps=eps,
+                elementwise_affine=elementwise_affine,
+                bias=bias,
             )
         )
 
 
 class SegmentedLayerNorm(nn.LayerNorm):
+    """Layer normalization that respects variable-length segments.
+
+    Parameters
+    ----------
+    channels : int
+        Number of feature channels.
+    eps : float, optional
+        A value added to the denominator for numerical stability. Defaults to ``1e-5``.
+    elementwise_affine : bool, optional
+        If ``True`` learn per-channel affine parameters. Defaults to ``True``.
+    bias : bool, optional
+        Whether to include a bias term. Defaults to ``True``.
+    """
 
     def __init__(
-        self, channels: int, eps: float = 1e-5, elementwise_affine: bool = True, bias: bool = True
+        self,
+        channels: int,
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+        bias: bool = True,
     ):
-        super().__init__([channels], eps=eps, elementwise_affine=elementwise_affine, bias=bias)
+        super().__init__(
+            [channels], eps=eps, elementwise_affine=elementwise_affine, bias=bias
+        )
 
     def forward(self, x: Geometry):
         # Only works for geometry with batched features
@@ -84,15 +140,47 @@ class SegmentedLayerNorm(nn.LayerNorm):
 
 
 class InstanceNorm(NormalizationBase):
+    """Applies :class:`torch.nn.InstanceNorm1d` to ``Geometry`` features.
+
+    Parameters
+    ----------
+    num_features : int
+        Number of feature channels in the input.
+    eps : float, optional
+        Value added to the denominator for numerical stability. Defaults to ``1e-5``.
+    """
+
     def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__(nn.InstanceNorm1d(num_features, eps=eps))
 
 
 class GroupNorm(NormalizationBase):
+    """Applies :class:`torch.nn.GroupNorm` to ``Geometry`` features.
+
+    Parameters
+    ----------
+    num_groups : int
+        Number of groups to separate the channels into.
+    num_channels : int
+        Number of channels expected in the input.
+    eps : float, optional
+        Value added to the denominator for numerical stability. Defaults to ``1e-5``.
+    """
+
     def __init__(self, num_groups: int, num_channels: int, eps: float = 1e-5):
         super().__init__(nn.GroupNorm(num_groups, num_channels, eps=eps))
 
 
 class RMSNorm(NormalizationBase):
+    """Applies :class:`torch.nn.RMSNorm` to ``Geometry`` features.
+
+    Parameters
+    ----------
+    dim : int
+        Number of input features.
+    eps : float, optional
+        Value added to the denominator for numerical stability. Defaults to ``1e-6``.
+    """
+
     def __init__(self, dim: int, eps: float = 1e-6):
         super().__init__(nn.RMSNorm(dim, eps=eps))

--- a/warpconvnet/nn/modules/point_pool.py
+++ b/warpconvnet/nn/modules/point_pool.py
@@ -11,10 +11,36 @@ from warpconvnet.nn.functional.point_pool import point_pool
 from warpconvnet.nn.functional.point_unpool import FEATURE_UNPOOLING_MODE, point_unpool
 from warpconvnet.ops.reductions import REDUCTIONS
 
-__all__ = ["PointPoolBase", "PointMaxPool", "PointAvgPool", "PointSumPool", "PointUnpool"]
+__all__ = [
+    "PointPoolBase",
+    "PointMaxPool",
+    "PointAvgPool",
+    "PointSumPool",
+    "PointUnpool",
+]
 
 
 class PointPoolBase(BaseSpatialModule):
+    """Base module for pooling points or voxels.
+
+    Parameters
+    ----------
+    reduction : str or :class:`REDUCTIONS`, optional
+        Reduction method used when merging features. Defaults to ``REDUCTIONS.MAX``.
+    downsample_max_num_points : int, optional
+        Maximum number of points to keep when downsampling.
+    downsample_voxel_size : float, optional
+        Size of voxels used for downsampling.
+    return_type : {"point", "sparse"}, optional
+        Output geometry type. Defaults to ``"point"``.
+    unique_method : {"torch", "ravel", "morton"}, optional
+        Method used to find unique voxel indices. Defaults to ``"torch"``.
+    avereage_pooled_coordinates : bool, optional
+        If ``True`` average coordinates of points within each voxel. Defaults to ``False``.
+    return_neighbor_search_result : bool, optional
+        If ``True`` also return the neighbor search result. Defaults to ``False``.
+    """
+
     def __init__(
         self,
         reduction: Union[str, REDUCTIONS] = REDUCTIONS.MAX,
@@ -50,6 +76,20 @@ class PointPoolBase(BaseSpatialModule):
 
 
 class PointMaxPool(PointPoolBase):
+    """Point pooling using ``max`` reduction.
+
+    Parameters
+    ----------
+    downsample_max_num_points : int, optional
+        Maximum number of points to keep when downsampling.
+    downsample_voxel_size : float, optional
+        Size of voxels used for downsampling.
+    return_type : {"point", "sparse"}, optional
+        Output geometry type. Defaults to ``"point"``.
+    return_neighbor_search_result : bool, optional
+        If ``True`` also return the neighbor search result. Defaults to ``False``.
+    """
+
     def __init__(
         self,
         downsample_max_num_points: Optional[int] = None,
@@ -67,6 +107,20 @@ class PointMaxPool(PointPoolBase):
 
 
 class PointAvgPool(PointPoolBase):
+    """Point pooling using ``mean`` reduction.
+
+    Parameters
+    ----------
+    downsample_max_num_points : int, optional
+        Maximum number of points to keep when downsampling.
+    downsample_voxel_size : float, optional
+        Size of voxels used for downsampling.
+    return_type : {"point", "sparse"}, optional
+        Output geometry type. Defaults to ``"point"``.
+    return_neighbor_search_result : bool, optional
+        If ``True`` also return the neighbor search result. Defaults to ``False``.
+    """
+
     def __init__(
         self,
         downsample_max_num_points: Optional[int] = None,
@@ -84,6 +138,20 @@ class PointAvgPool(PointPoolBase):
 
 
 class PointSumPool(PointPoolBase):
+    """Point pooling using ``sum`` reduction.
+
+    Parameters
+    ----------
+    downsample_max_num_points : int, optional
+        Maximum number of points to keep when downsampling.
+    downsample_voxel_size : float, optional
+        Size of voxels used for downsampling.
+    return_type : {"point", "sparse"}, optional
+        Output geometry type. Defaults to ``"point"``.
+    return_neighbor_search_result : bool, optional
+        If ``True`` also return the neighbor search result. Defaults to ``False``.
+    """
+
     def __init__(
         self,
         downsample_max_num_points: Optional[int] = None,
@@ -101,9 +169,21 @@ class PointSumPool(PointPoolBase):
 
 
 class PointUnpool(BaseSpatialModule):
+    """Undo point pooling by scattering pooled features back to the input cloud.
+
+    Parameters
+    ----------
+    unpooling_mode : {"repeat", "interpolate"} or :class:`FEATURE_UNPOOLING_MODE`, optional
+        Strategy used when unpooling features. Defaults to ``FEATURE_UNPOOLING_MODE.REPEAT``.
+    concat_unpooled_pc : bool, optional
+        If ``True`` concatenate the unpooled point cloud with the input. Defaults to ``False``.
+    """
+
     def __init__(
         self,
-        unpooling_mode: Union[str, FEATURE_UNPOOLING_MODE] = FEATURE_UNPOOLING_MODE.REPEAT,
+        unpooling_mode: Union[
+            str, FEATURE_UNPOOLING_MODE
+        ] = FEATURE_UNPOOLING_MODE.REPEAT,
         concat_unpooled_pc: bool = False,
     ):
         super().__init__()

--- a/warpconvnet/nn/modules/sparse_conv.py
+++ b/warpconvnet/nn/modules/sparse_conv.py
@@ -28,6 +28,46 @@ from warpconvnet.constants import (
 
 
 class SpatiallySparseConv(BaseSpatialModule):
+    """Sparse convolution layer for :class:`~warpconvnet.geometry.types.voxels.Voxels`.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input feature channels.
+    out_channels : int
+        Number of output feature channels.
+    kernel_size : int or tuple of int
+        Size of the convolution kernel.
+    stride : int or tuple of int, optional
+        Convolution stride. Defaults to ``1``.
+    dilation : int or tuple of int, optional
+        Spacing between kernel elements. Defaults to ``1``.
+    bias : bool, optional
+        If ``True`` adds a learnable bias to the output. Defaults to ``True``.
+    transposed : bool, optional
+        Perform a transposed convolution. Defaults to ``False``.
+    generative : bool, optional
+        Use generative convolution. Defaults to ``False``.
+    kernel_matmul_batch_size : int, optional
+        Batch size used for implicit matrix multiplications. Defaults to ``2``.
+    num_spatial_dims : int, optional
+        Number of spatial dimensions. Defaults to ``3``.
+    fwd_algo : :class:`SPARSE_CONV_FWD_ALGO_MODE` or str, optional
+        Forward algorithm to use. Defaults to environment setting.
+    bwd_algo : :class:`SPARSE_CONV_BWD_ALGO_MODE` or str, optional
+        Backward algorithm to use. Defaults to environment setting.
+    stride_mode : :class:`STRIDED_CONV_MODE`, optional
+        How to interpret ``stride`` when ``transposed`` is ``True``.
+    order : :class:`POINT_ORDERING`, optional
+        Ordering of points in the output. Defaults to ``POINT_ORDERING.RANDOM``.
+    compute_dtype : torch.dtype, optional
+        Data type used for intermediate computations.
+    implicit_matmul_fwd_block_size : int, optional
+        CUDA block size for implicit forward matmuls.
+    implicit_matmul_bwd_block_size : int, optional
+        CUDA block size for implicit backward matmuls.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -74,10 +114,14 @@ class SpatiallySparseConv(BaseSpatialModule):
 
         # If string, update to enum
         self.fwd_algo = (
-            SPARSE_CONV_FWD_ALGO_MODE(fwd_algo) if isinstance(fwd_algo, str) else fwd_algo
+            SPARSE_CONV_FWD_ALGO_MODE(fwd_algo)
+            if isinstance(fwd_algo, str)
+            else fwd_algo
         )
         self.bwd_algo = (
-            SPARSE_CONV_BWD_ALGO_MODE(bwd_algo) if isinstance(bwd_algo, str) else bwd_algo
+            SPARSE_CONV_BWD_ALGO_MODE(bwd_algo)
+            if isinstance(bwd_algo, str)
+            else bwd_algo
         )
         self.stride_mode = stride_mode
         self.order = order
@@ -87,7 +131,9 @@ class SpatiallySparseConv(BaseSpatialModule):
 
         self.bias: Optional[nn.Parameter] = None
 
-        self.weight = nn.Parameter(torch.randn(np.prod(_kernel_size), in_channels, out_channels))
+        self.weight = nn.Parameter(
+            torch.randn(np.prod(_kernel_size), in_channels, out_channels)
+        )
         if bias:
             self.bias = nn.Parameter(torch.randn(out_channels))
         else:
@@ -123,7 +169,9 @@ class SpatiallySparseConv(BaseSpatialModule):
         fan_in, fan_out = self._calculate_fan_in_and_fan_out()
         return fan_in if mode == "fan_in" else fan_out
 
-    def _custom_kaiming_uniform_(self, tensor, a=0, mode="fan_in", nonlinearity="leaky_relu"):
+    def _custom_kaiming_uniform_(
+        self, tensor, a=0, mode="fan_in", nonlinearity="leaky_relu"
+    ):
         fan = self._calculate_correct_fan(mode)
         gain = calculate_gain(nonlinearity, a)
         std = gain / math.sqrt(fan)
@@ -171,6 +219,44 @@ class SpatiallySparseConv(BaseSpatialModule):
 
 
 class SparseConv2d(SpatiallySparseConv):
+    """2D sparse convolution.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input feature channels.
+    out_channels : int
+        Number of output feature channels.
+    kernel_size : int or tuple of int
+        Size of the convolution kernel.
+    stride : int or tuple of int, optional
+        Convolution stride. Defaults to ``1``.
+    dilation : int or tuple of int, optional
+        Spacing between kernel elements. Defaults to ``1``.
+    bias : bool, optional
+        If ``True`` adds a learnable bias to the output. Defaults to ``True``.
+    transposed : bool, optional
+        Perform a transposed convolution. Defaults to ``False``.
+    generative : bool, optional
+        Use generative convolution. Defaults to ``False``.
+    stride_mode : :class:`STRIDED_CONV_MODE`, optional
+        How to interpret ``stride`` when ``transposed`` is ``True``.
+    fwd_algo : :class:`SPARSE_CONV_FWD_ALGO_MODE` or str, optional
+        Forward algorithm to use.
+    bwd_algo : :class:`SPARSE_CONV_BWD_ALGO_MODE` or str, optional
+        Backward algorithm to use.
+    kernel_matmul_batch_size : int, optional
+        Batch size used for implicit matrix multiplications. Defaults to ``2``.
+    order : :class:`POINT_ORDERING`, optional
+        Ordering of points in the output. Defaults to ``POINT_ORDERING.RANDOM``.
+    compute_dtype : torch.dtype, optional
+        Data type used for intermediate computations.
+    implicit_matmul_fwd_block_size : int, optional
+        CUDA block size for implicit forward matmuls.
+    implicit_matmul_bwd_block_size : int, optional
+        CUDA block size for implicit backward matmuls.
+    """
+
     def __init__(
         self,
         in_channels,
@@ -212,6 +298,44 @@ class SparseConv2d(SpatiallySparseConv):
 
 
 class SparseConv3d(SpatiallySparseConv):
+    """3D sparse convolution.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input feature channels.
+    out_channels : int
+        Number of output feature channels.
+    kernel_size : int or tuple of int
+        Size of the convolution kernel.
+    stride : int or tuple of int, optional
+        Convolution stride. Defaults to ``1``.
+    dilation : int or tuple of int, optional
+        Spacing between kernel elements. Defaults to ``1``.
+    bias : bool, optional
+        If ``True`` adds a learnable bias to the output. Defaults to ``True``.
+    transposed : bool, optional
+        Perform a transposed convolution. Defaults to ``False``.
+    generative : bool, optional
+        Use generative convolution. Defaults to ``False``.
+    stride_mode : :class:`STRIDED_CONV_MODE`, optional
+        How to interpret ``stride`` when ``transposed`` is ``True``.
+    fwd_algo : :class:`SPARSE_CONV_FWD_ALGO_MODE` or str, optional
+        Forward algorithm to use.
+    bwd_algo : :class:`SPARSE_CONV_BWD_ALGO_MODE` or str, optional
+        Backward algorithm to use.
+    kernel_matmul_batch_size : int, optional
+        Batch size used for implicit matrix multiplications. Defaults to ``2``.
+    order : :class:`POINT_ORDERING`, optional
+        Ordering of points in the output. Defaults to ``POINT_ORDERING.RANDOM``.
+    compute_dtype : torch.dtype, optional
+        Data type used for intermediate computations.
+    implicit_matmul_fwd_block_size : int, optional
+        CUDA block size for implicit forward matmuls.
+    implicit_matmul_bwd_block_size : int, optional
+        CUDA block size for implicit backward matmuls.
+    """
+
     def __init__(
         self,
         in_channels,

--- a/warpconvnet/nn/modules/sparse_pool.py
+++ b/warpconvnet/nn/modules/sparse_pool.py
@@ -18,6 +18,18 @@ from warpconvnet.ops.reductions import REDUCTION_TYPES_STR, REDUCTIONS
 
 
 class SparsePool(BaseSpatialModule):
+    """Reduce features of a ``Voxels`` object using a strided kernel.
+
+    Parameters
+    ----------
+    kernel_size : int
+        Size of the pooling kernel.
+    stride : int
+        Stride between pooling windows.
+    reduce : {"max", "min", "mean", "sum", "random"}, optional
+        Reduction to apply within each window. Defaults to ``"max"``.
+    """
+
     def __init__(
         self,
         kernel_size: int,
@@ -42,6 +54,16 @@ class SparsePool(BaseSpatialModule):
 
 
 class SparseMaxPool(SparsePool):
+    """Max pooling for sparse tensors.
+
+    Parameters
+    ----------
+    kernel_size : int
+        Size of the pooling kernel.
+    stride : int
+        Stride between pooling windows.
+    """
+
     def __init__(
         self,
         kernel_size: int,
@@ -51,6 +73,16 @@ class SparseMaxPool(SparsePool):
 
 
 class SparseMinPool(SparsePool):
+    """Min pooling for sparse tensors.
+
+    Parameters
+    ----------
+    kernel_size : int
+        Size of the pooling kernel.
+    stride : int
+        Stride between pooling windows.
+    """
+
     def __init__(
         self,
         kernel_size: int,
@@ -60,6 +92,14 @@ class SparseMinPool(SparsePool):
 
 
 class GlobalPool(BaseSpatialModule):
+    """Pool features across the entire geometry.
+
+    Parameters
+    ----------
+    reduce : {"min", "max", "mean", "sum"}, optional
+        Reduction to apply over all features. Defaults to ``"max"``.
+    """
+
     def __init__(self, reduce: Literal["min", "max", "mean", "sum"] = "max"):
         super().__init__()
         self.reduce = reduce
@@ -69,6 +109,18 @@ class GlobalPool(BaseSpatialModule):
 
 
 class SparseUnpool(BaseSpatialModule):
+    """Unpool a sparse tensor back to a higher resolution.
+
+    Parameters
+    ----------
+    kernel_size : int
+        Size of the unpooling kernel.
+    stride : int
+        Stride between unpooling windows.
+    concat_unpooled_st : bool, optional
+        If ``True`` concatenate the unpooled tensor with the input. Defaults to ``True``.
+    """
+
     def __init__(self, kernel_size: int, stride: int, concat_unpooled_st: bool = True):
         super().__init__()
         self.kernel_size = kernel_size
@@ -86,10 +138,20 @@ class SparseUnpool(BaseSpatialModule):
 
 
 class PointToSparseWrapper(BaseSpatialModule):
-    """
-    A module that pools points to a spatially sparse tensor given a voxel size and pass it to the inner module.
+    """Pool points into a sparse tensor, apply an inner module and unpool back to points.
 
-    The output of the inner module is then converted back to a point cloud.
+    Parameters
+    ----------
+    inner_module : :class:`BaseSpatialModule`
+        Module applied on the pooled sparse tensor.
+    voxel_size : float
+        Voxel size used to pool the input points.
+    reduction : :class:`REDUCTIONS` or str, optional
+        Reduction used when pooling points. Defaults to ``REDUCTIONS.MEAN``.
+    unique_method : {"morton", "ravel", "torch"}, optional
+        Method used for hashing voxel indices. Defaults to ``"morton"``.
+    concat_unpooled_pc : bool, optional
+        If ``True`` concatenate the unpooled result with the original input. Defaults to ``True``.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- add MkDocs configuration for Python API docs
- create documentation skeleton with getting started guides and API reference

## Testing
- `mkdocs build -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'warpconvnet')*

------
https://chatgpt.com/codex/tasks/task_e_6878db86fb808333af7db139149d552a